### PR TITLE
[SMP-893]: Removing docker.io prefix from the configmap

### DIFF
--- a/src/ci-manager/Chart.yaml
+++ b/src/ci-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.24
+version: 0.2.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/ci-manager/README.md
+++ b/src/ci-manager/README.md
@@ -1,6 +1,6 @@
 # ci-manager
 
-![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.2.25](https://img.shields.io/badge/Version-0.2.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -24,7 +24,7 @@ A Helm chart for Kubernetes
 | ci_images.addon.image.imagePullSecrets | list | `[]` |  |
 | ci_images.addon.image.registry | string | `"docker.io"` |  |
 | ci_images.addon.image.repository | string | `"harness/ci-addon"` |  |
-| ci_images.addon.image.tag | string | `"1.14.21"` |  |
+| ci_images.addon.image.tag | string | `"1.16.1-linux-amd64"` |  |
 | ci_images.artifactory_upload.image.digest | string | `""` |  |
 | ci_images.artifactory_upload.image.imagePullSecrets | list | `[]` |  |
 | ci_images.artifactory_upload.image.registry | string | `"docker.io"` |  |
@@ -34,7 +34,7 @@ A Helm chart for Kubernetes
 | ci_images.gcs_cache.image.imagePullSecrets | list | `[]` |  |
 | ci_images.gcs_cache.image.registry | string | `"docker.io"` |  |
 | ci_images.gcs_cache.image.repository | string | `"plugins/cache"` |  |
-| ci_images.gcs_cache.image.tag | string | `"1.4.2"` |  |
+| ci_images.gcs_cache.image.tag | string | `"1.4.3"` |  |
 | ci_images.gcs_upload.image.digest | string | `""` |  |
 | ci_images.gcs_upload.image.imagePullSecrets | list | `[]` |  |
 | ci_images.gcs_upload.image.registry | string | `"docker.io"` |  |
@@ -44,7 +44,7 @@ A Helm chart for Kubernetes
 | ci_images.git_clone.image.imagePullSecrets | list | `[]` |  |
 | ci_images.git_clone.image.registry | string | `"docker.io"` |  |
 | ci_images.git_clone.image.repository | string | `"harness/drone-git"` |  |
-| ci_images.git_clone.image.tag | string | `"1.2.4-rootless"` |  |
+| ci_images.git_clone.image.tag | string | `"1.2.7-rootless"` |  |
 | ci_images.kaniko.image.digest | string | `""` |  |
 | ci_images.kaniko.image.imagePullSecrets | list | `[]` |  |
 | ci_images.kaniko.image.registry | string | `"docker.io"` |  |
@@ -64,12 +64,12 @@ A Helm chart for Kubernetes
 | ci_images.lite_engine.image.imagePullSecrets | list | `[]` |  |
 | ci_images.lite_engine.image.registry | string | `"docker.io"` |  |
 | ci_images.lite_engine.image.repository | string | `"harness/ci-lite-engine"` |  |
-| ci_images.lite_engine.image.tag | string | `"1.14.21"` |  |
+| ci_images.lite_engine.image.tag | string | `"1.16.1-linux-amd64"` |  |
 | ci_images.s3_cache.image.digest | string | `""` |  |
 | ci_images.s3_cache.image.imagePullSecrets | list | `[]` |  |
 | ci_images.s3_cache.image.registry | string | `"docker.io"` |  |
 | ci_images.s3_cache.image.repository | string | `"plugins/cache"` |  |
-| ci_images.s3_cache.image.tag | string | `"1.4.2"` |  |
+| ci_images.s3_cache.image.tag | string | `"1.4.3"` |  |
 | ci_images.s3_upload.image.digest | string | `""` |  |
 | ci_images.s3_upload.image.imagePullSecrets | list | `[]` |  |
 | ci_images.s3_upload.image.registry | string | `"docker.io"` |  |
@@ -85,7 +85,7 @@ A Helm chart for Kubernetes
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` |  |
 | image.repository | string | `"harness/ci-manager-signed"` |  |
-| image.tag | string | `"1714"` |  |
+| image.tag | string | `"2303"` |  |
 | java.memory | int | `4096` |  |
 | maxSurge | int | `1` |  |
 | maxUnavailable | int | `0` |  |

--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -13,17 +13,18 @@ data:
   MANAGER_AUTHORITY: harness-manager:9879
   GRPC_SERVER_PORT: {{.Values.service.grpcport | quote}}
   SCM_SERVICE_URI: "scm-service:8091"
-  ADDON_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.addon.image "global" .Values.global) }}
-  LE_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.lite_engine.image "global" .Values.global) }}
-  GIT_CLONE_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.git_clone.image "global" .Values.global) }}
-  DOCKER_PUSH_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.kaniko.image "global" .Values.global) }}
-  ECR_PUSH_IMAGE:  {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.kaniko_ecr.image "global" .Values.global) }}
-  GCR_PUSH_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.kaniko_gcr.image "global" .Values.global) }}
-  GCS_UPLOAD_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.gcs_upload.image "global" .Values.global) }}
-  S3_UPLOAD_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.s3_upload.image "global" .Values.global) }}
-  ARTIFACTORY_UPLOAD_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.artifactory_upload.image "global" .Values.global) }}
-  GCS_CACHE_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.gcs_cache.image "global" .Values.global) }}
-  S3_CACHE_IMAGE: {{ include "common.images.image" (dict "imageRoot" .Values.ci_images.s3_cache.image "global" .Values.global) }}
+  ADDON_IMAGE: '{{ .Values.ci_images.addon.image.repository }}:{{ .Values.ci_images.addon.image.tag }}'
+  LE_IMAGE: '{{ .Values.ci_images.lite_engine.image.repository }}:{{ .Values.ci_images.lite_engine.image.tag }}'
+  GIT_CLONE_IMAGE: '{{ .Values.ci_images.git_clone.image.repository }}:{{ .Values.ci_images.git_clone.image.tag }}'
+  DOCKER_PUSH_IMAGE: '{{ .Values.ci_images.kaniko.image.repository }}:{{ .Values.ci_images.kaniko.image.tag }}'
+  ECR_PUSH_IMAGE: '{{ .Values.ci_images.kaniko_ecr.image.repository }}:{{ .Values.ci_images.kaniko_ecr.image.tag }}'
+  GCR_PUSH_IMAGE: '{{ .Values.ci_images.kaniko_gcr.image.repository }}:{{ .Values.ci_images.kaniko_gcr.image.tag }}'
+  GCS_UPLOAD_IMAGE: '{{ .Values.ci_images.gcs_upload.image.repository }}:{{ .Values.ci_images.gcs_upload.image.tag }}'
+  S3_UPLOAD_IMAGE: '{{ .Values.ci_images.s3_upload.image.repository }}:{{ .Values.ci_images.s3_upload.image.tag }}'
+  ARTIFACTORY_UPLOAD_IMAGE: '{{ .Values.ci_images.artifactory_upload.image.repository }}:{{ .Values.ci_images.artifactory_upload.image.tag }}'
+  GCS_CACHE_IMAGE: '{{ .Values.ci_images.gcs_cache.image.repository }}:{{ .Values.ci_images.gcs_cache.image.tag }}'
+  S3_CACHE_IMAGE: '{{ .Values.ci_images.s3_cache.image.repository }}:{{ .Values.ci_images.s3_cache.image.tag }}'
+  SECURITY_IMAGE: {{ include "ci-manager.securityImage" . }}
   PMS_TARGET:  pipeline-service:12011
   PMS_AUTHORITY:  pipeline-service:12011
   LOGGING_LEVEL: {{ .Values.appLogLevel }}
@@ -53,6 +54,5 @@ data:
   {{- end }}
   API_URL: '{{ .Values.global.loadbalancerURL }}/ng/#/'
   STO_SERVICE_ENDPOINT: '{{ .Values.global.loadbalancerURL }}/sto/'
-  SECURITY_IMAGE: {{ include "ci-manager.securityImage" . }}
   LOG_SERVICE_GLOBAL_TOKEN: c76e567a-b341-404d-a8dd-d9738714eb82
   TI_SERVICE_GLOBAL_TOKEN: 78d16b66-4b4c-11eb-8377-acde48001122

--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -24,7 +24,7 @@ data:
   ARTIFACTORY_UPLOAD_IMAGE: '{{ .Values.ci_images.artifactory_upload.image.repository }}:{{ .Values.ci_images.artifactory_upload.image.tag }}'
   GCS_CACHE_IMAGE: '{{ .Values.ci_images.gcs_cache.image.repository }}:{{ .Values.ci_images.gcs_cache.image.tag }}'
   S3_CACHE_IMAGE: '{{ .Values.ci_images.s3_cache.image.repository }}:{{ .Values.ci_images.s3_cache.image.tag }}'
-  SECURITY_IMAGE: {{ include "ci-manager.securityImage" . }}
+  SECURITY_IMAGE: '{{ .Values.securityImage.image.repository }}:{{ .Values.securityImage.image.tag }}'
   PMS_TARGET:  pipeline-service:12011
   PMS_AUTHORITY:  pipeline-service:12011
   LOGGING_LEVEL: {{ .Values.appLogLevel }}


### PR DESCRIPTION
Removing docker.io prefix from CI-manager configmap to use internal harness connector instead.

Currently, we are using helm function to prefix where the CI images are coming from. It does not support to taking in imagePullSecrets passed as envVar(configmap). Harness instead supports internal image connector where you can pass json token (imagePullSecret) on UI which can work with existing image connectors. 