### PR TITLE
SMP-991: Enable STACK_DRIVER_LOGGING_ENABLED for all services

### DIFF
--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -50,3 +50,4 @@ data:
   STO_SERVICE_ENDPOINT: '{{ .Values.global.loadbalancerURL }}/sto/'
   LOG_SERVICE_GLOBAL_TOKEN: c76e567a-b341-404d-a8dd-d9738714eb82
   TI_SERVICE_GLOBAL_TOKEN: 78d16b66-4b4c-11eb-8377-acde48001122
+  STACK_DRIVER_LOGGING_ENABLED: {{ .Values.global.stackDriverLoggingEnabled | quote }}

--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -51,3 +51,6 @@ data:
   LOG_SERVICE_GLOBAL_TOKEN: c76e567a-b341-404d-a8dd-d9738714eb82
   TI_SERVICE_GLOBAL_TOKEN: 78d16b66-4b4c-11eb-8377-acde48001122
   STACK_DRIVER_LOGGING_ENABLED: {{ .Values.global.stackDriverLoggingEnabled | quote }}
+{{- if .Values.additionalConfigs }}
+  {{- toYaml .Values.additionalConfigs | nindent 2 }}
+{{- end }}

--- a/src/ci-manager/values.yaml
+++ b/src/ci-manager/values.yaml
@@ -84,7 +84,7 @@ ci_images:
       tag: "1.7.0"
       repository: plugins/kaniko-gcr
       imagePullSecrets: []
-      
+
   kaniko_acr:
     image:
       registry: docker.io
@@ -207,3 +207,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+additionalConfigs: {}

--- a/src/ci-manager/values.yaml
+++ b/src/ci-manager/values.yaml
@@ -5,6 +5,7 @@ global:
   loadbalancerURL: ""
   airgap: false
   imagePullSecrets: []
+  stackDriverLoggingEnabled: false
 replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0


### PR DESCRIPTION
1. Added the `stackDriverLoggingEnabled` option in the global values.
2. Added `additionalConfigs` options to provide any additional configurations to any of the services