### PR TITLE
SMP-1268: Remove cpu under resources.limits

### DIFF
--- a/src/ci-manager/values.yaml
+++ b/src/ci-manager/values.yaml
@@ -210,7 +210,6 @@ service:
   grpcport: 9979
 resources:
   limits:
-    cpu: 1
     memory: 8192Mi
   requests:
     cpu: 1


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)