### PR TITLE
SMP-1551: add ENABLE_AUTH to ConfigMap

### DIFF
--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -9,7 +9,7 @@ data:
   CACHE_CONFIG_SENTINEL_MASTER_NAME: "harness-redis"
   CACHE_CONFIG_USE_SENTINEL: "true"
   DEPLOY_MODE: KUBERNETES_ONPREM
-  ENABLE_AUTH: {{.Values.enableAuth | quote}}
+  ENABLE_AUTH: {{ .Values.enableAuth | quote }}
   MANAGER_TARGET: harness-manager:9879
   MANAGER_AUTHORITY: harness-manager:9879
   GRPC_SERVER_PORT: {{.Values.service.grpcport | quote}}

--- a/src/ci-manager/templates/config.yaml
+++ b/src/ci-manager/templates/config.yaml
@@ -9,6 +9,7 @@ data:
   CACHE_CONFIG_SENTINEL_MASTER_NAME: "harness-redis"
   CACHE_CONFIG_USE_SENTINEL: "true"
   DEPLOY_MODE: KUBERNETES_ONPREM
+  ENABLE_AUTH: {{.Values.enableAuth | quote}}
   MANAGER_TARGET: harness-manager:9879
   MANAGER_AUTHORITY: harness-manager:9879
   GRPC_SERVER_PORT: {{.Values.service.grpcport | quote}}

--- a/src/ci-manager/values.yaml
+++ b/src/ci-manager/values.yaml
@@ -53,6 +53,7 @@ global:
       passwordKey: "redis-password"
       extraArgs: ""
 
+enableAuth: true
 replicaCount: 1
 maxSurge: 1
 maxUnavailable: 0


### PR DESCRIPTION
Cherry-picking SMP-1551: add ENABLE_AUTH to ConfigMap changes: https://github.com/harness/helm-ci-manager/pull/58/commits/b3fa8ad9db28bfae416923b00f9680913378380c

Refer https://harness.atlassian.net/browse/CI-8579

Tracking Jira: https://harness.atlassian.net/browse/SMP-1551 